### PR TITLE
Use DssExecLib code v0.0.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all    :; DAPP_LIBRARIES=' lib/dss-exec-lib/src/DssExecLib.sol:DssExecLib:0x0aAcC3bd8852a51538C57918b9E94952A8acE5Da' \
+all    :; DAPP_LIBRARIES=' lib/dss-exec-lib/src/DssExecLib.sol:DssExecLib:0xa81598667ac561986b70ae11bbe2dd5348ed4327' \
           DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=1 \
           dapp --use solc:0.6.12 build
 clean  :; dapp clean

--- a/shell.nix
+++ b/shell.nix
@@ -8,7 +8,7 @@ mkShell {
   DAPP_SOLC = solc-static-versions.solc_0_6_12 + "/bin/solc-0.6.12";
   DAPP_BUILD_OPTIMIZE = 1;
   DAPP_BUILD_OPTIMIZE_RUNS = 1;
-  DAPP_LIBRARIES = " lib/dss-exec-lib/src/DssExecLib.sol:DssExecLib:0x0aAcC3bd8852a51538C57918b9E94952A8acE5Da";
+  DAPP_LIBRARIES = " lib/dss-exec-lib/src/DssExecLib.sol:DssExecLib:0xa81598667ac561986b70ae11bbe2dd5348ed4327";
   DAPP_LINK_TEST_LIBRARIES = 0;
   buildInputs = [
     dapp

--- a/test-dssspell.sh
+++ b/test-dssspell.sh
@@ -5,7 +5,8 @@ set -e
 
 export DAPP_BUILD_OPTIMIZE=1
 export DAPP_BUILD_OPTIMIZE_RUNS=1
-export DAPP_LIBRARIES=' lib/dss-exec-lib/src/DssExecLib.sol:DssExecLib:0x0aAcC3bd8852a51538C57918b9E94952A8acE5Da'
+# DssExecLib 0.0.7
+export DAPP_LIBRARIES=' lib/dss-exec-lib/src/DssExecLib.sol:DssExecLib:0xa81598667ac561986b70ae11bbe2dd5348ed4327'
 export DAPP_LINK_TEST_LIBRARIES=0
 
 if [[ -z "$1" ]]; then


### PR DESCRIPTION
Uses DssExecLib code tagged to `v0.0.7` release.

I've deployed a new DssExecLib to Goerli because the one that's existing here is pointing to `master`, which is a little different than the `0.0.7` release on mainnet. We should use this code because if there is any issue with using this version we will discover it here before we roll over to prod.