### PR TITLE
Port improvements from Feb 4th mainnet spell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 all             :; DAPP_LIBRARIES=' lib/dss-exec-lib/src/DssExecLib.sol:DssExecLib:$(shell cat DssExecLib.address)' \
-		    DAPP_BUILD_OPTIMIZE=0 DAPP_BUILD_OPTIMIZE_RUNS=200 \
-		    dapp --use solc:0.6.12 build
+                    DAPP_BUILD_OPTIMIZE=0 DAPP_BUILD_OPTIMIZE_RUNS=200 \
+                    dapp --use solc:0.6.12 build
 clean           :; dapp clean
+                    # Usage example: make test match=SpellIsCast
 test            :; ./test-dssspell.sh match="$(match)" optimizer="$(optimizer)"
 test-dev        :; ./test-dssspell.sh match="$(match)" optimizer="0"
 test-forge      :; ./test-dssspell-forge.sh match="$(match)" block="$(block)"
 deploy          :; make && dapp create DssSpell | xargs ./verify.py DssSpell
+estimate        :; ./estimate-deploy-gas.sh
 flatten         :; hevm flatten --source-file "src/Goerli-DssSpell.sol" > out/flat.sol
 archive-spell   :; ./archive-dssspell.sh "$(if $(date),$(date),$(shell date +'%Y-%m-%d'))"

--- a/archive-dssspell.sh
+++ b/archive-dssspell.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-
 if [[ -z "$1" ]]; then
   echo "You must provide a name option to name the directory"
 else

--- a/archive-dssspell.sh
+++ b/archive-dssspell.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [[ -z "$1" ]]; then
-  echo "You must provide a name option to name the directory"
+  echo "You must provide a date (YYYY-MM-DD) option to name the directory"
 else
   mkdir "./archive/$1-DssSpell"
   mkdir "./archive/$1-DssSpell/test"

--- a/archive/2022-01-27-DssSpell/Goerli-DssSpell.t.sol
+++ b/archive/2022-01-27-DssSpell/Goerli-DssSpell.t.sol
@@ -89,7 +89,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
             if (_name == "DEPLOYER" ||
                 _name == "ETH"||
                 _name == "PROXY_DEPLOYER"
-                ) { continue; }
+            ) { continue; }
             address _addr = chainLog.getAddress(_name);
             (bool ok, bytes memory val) = _addr.call(abi.encodeWithSignature("wards(address)", _oldEsm));
             log_bytes(val);

--- a/archive/2022-01-27-DssSpell/Goerli-DssSpell.t.sol
+++ b/archive/2022-01-27-DssSpell/Goerli-DssSpell.t.sol
@@ -19,10 +19,6 @@ pragma solidity 0.6.12;
 
 import "./Goerli-DssSpell.t.base.sol";
 
-interface DenyProxyLike {
-    function denyProxy(address) external;
-}
-
 contract DssSpellTest is GoerliDssSpellTestBase {
 
     function testSpellIsCast_GENERAL() public {
@@ -105,7 +101,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
                 }
             }
         }
-        assertTrue(items.length > 0);
+        assertEq(items.length, 43);
 
         vote(address(spell));
         scheduleWaitAndCast(address(spell));
@@ -142,7 +138,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
 
         ClipAbstract clipLINKA = ClipAbstract(addr.addr("MCD_CLIP_LINK_A"));
         assertEq(clipLINKA.wards(address(pauseProxy)), 1);
-        DenyProxyLike(address(esm)).denyProxy(address(clipLINKA));
+        ESMAbstract(address(esm)).denyProxy(address(clipLINKA));
         assertEq(clipLINKA.wards(address(pauseProxy)), 0);
     }
 

--- a/verify.py
+++ b/verify.py
@@ -200,21 +200,6 @@ if 'addNewCollateral' not in remove_comments(code):
 
 def get_library_info():
     try:
-
-        # makefile = open('./Makefile').read()
-        # libraries_flags = re.findall('DAPP_LIBRARIES=\'(.*)\'', makefile)
-        # if len(libraries_flags) == 0:
-        #     raise ValueError('No library flags found in Makefile')
-        # libraries_flag = libraries_flags[0].strip().split(' ')
-        # if len(libraries_flag) > 1:
-        #     print(libraries_flag)
-        #     exit('Only one library supported.')
-        # library_flag = libraries_flag[0]
-        # library_components = library_flag.split(':')
-        # if len(library_components) != 3:
-        #     raise ValueError('Malformed library flag: ', library_components)
-        # library_name = library_components[1]
-        # library_address = library_components[2]
         library_name = "DssExecLib"
         library_address = open('./DssExecLib.address').read()
         return library_name, library_address


### PR DESCRIPTION
# Description

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in Goerli changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell to Goerli `ETH_GAS="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Ensure contract is verified on `Goerli` etherscan
- [ ] Change test to use Goerli spell address and deploy timestamp
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `Goerli-DssSpell.sol`, `Goerli-DssSpell.t.sol`, `Goerli-DssSpell.t.base.sol`, and `Goerli-DssSpellCollateralOnboarding.sol`
- [ ] `squash and merge` this PR
