### PR TITLE
Fix bug in test when new chainlog entries are added and version is changed

### DIFF
--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -447,6 +447,9 @@ contract DssSpellTest is GoerliDssSpellTestBase {
             if (keccak256(abi.encodePacked(_version)) == keccak256(abi.encodePacked(chainLog.version()))) {
                 emit log_named_string("Error", concat("TestError/chainlog-version-not-updated-count-change-", _version));
                 fail();
+            } else {
+                // Chainlog size changed and version is updated, so test passes.
+                return;
             }
         }
 

--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -447,7 +447,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
             // Chainlog version has been updated. Short circuit the test here.
             return;
         } else {
-            // Fail if the version is not updated and the chainlog count has not changed
+            // Fail if the version is not updated and the chainlog count has changed
             if (_count != chainLog.count()) {
                 emit log_named_string("Error", concat("TestError/chainlog-version-not-updated-count-change-", _version));
                 fail();

--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -443,10 +443,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
         scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
 
-        if (keccak256(abi.encodePacked(_version)) != keccak256(abi.encodePacked(chainLog.version()))) {
-            // Chainlog version has been updated. Short circuit the test here.
-            return;
-        } else {
+        if (keccak256(abi.encodePacked(_version)) == keccak256(abi.encodePacked(chainLog.version()))) {
             // Fail if the version is not updated and the chainlog count has changed
             if (_count != chainLog.count()) {
                 emit log_named_string("Error", concat("TestError/chainlog-version-not-updated-count-change-", _version));

--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -443,26 +443,23 @@ contract DssSpellTest is GoerliDssSpellTestBase {
         scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
 
-        if (_count != chainLog.count()) {
-            if (keccak256(abi.encodePacked(_version)) == keccak256(abi.encodePacked(chainLog.version()))) {
+        if (keccak256(abi.encodePacked(_version)) != keccak256(abi.encodePacked(chainLog.version()))) {
+            // Chainlog version has been updated. Short circuit the test here.
+            return;
+        } else {
+            // Fail if the version is not updated and the chainlog count has not changed
+            if (_count != chainLog.count()) {
                 emit log_named_string("Error", concat("TestError/chainlog-version-not-updated-count-change-", _version));
                 fail();
-            } else {
-                // Chainlog size changed and version is updated, so test passes.
-                return;
             }
-        }
-
-        for(uint256 i = 0; i < chainLog.count(); i++) {
-            (, address _val) = chainLog.get(i);
-            // If the address arrays don't match it's due to a change in the changelog. Fail if the version is not updated.
-            if (_chainlog_addrs[i] != _val) {
-                if (keccak256(abi.encodePacked(_version)) == keccak256(abi.encodePacked(chainLog.version()))) {
+            // Fail if the chainlog is the same size but local keys don't match the chainlog.
+            for(uint256 i = 0; i < chainLog.count(); i++) {
+                (, address _val) = chainLog.get(i);
+                if (address(_chainlog_addrs[i]) != address(_val)) {
                     emit log_named_string("Error", concat("TestError/chainlog-version-not-updated-address-change-", _version));
                     fail();
                 }
             }
         }
-
     }
 }

--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -448,6 +448,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
             if (_count != chainLog.count()) {
                 emit log_named_string("Error", concat("TestError/chainlog-version-not-updated-count-change-", _version));
                 fail();
+                return;
             }
             // Fail if the chainlog is the same size but local keys don't match the chainlog.
             for(uint256 i = 0; i < _count; i++) {
@@ -455,6 +456,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
                 if (_chainlog_addrs[i] != _val) {
                     emit log_named_string("Error", concat("TestError/chainlog-version-not-updated-address-change-", _version));
                     fail();
+                    return;
                 }
             }
         }

--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -450,7 +450,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
                 fail();
             }
             // Fail if the chainlog is the same size but local keys don't match the chainlog.
-            for(uint256 i = 0; i < chainLog.count(); i++) {
+            for(uint256 i = 0; i < _count; i++) {
                 (, address _val) = chainLog.get(i);
                 if (_chainlog_addrs[i] != _val) {
                     emit log_named_string("Error", concat("TestError/chainlog-version-not-updated-address-change-", _version));


### PR DESCRIPTION
Fixes the case where new entries are added to the changelog and the version is appropriately updated by short-circuiting the test.