### PR TITLE
update auth skipWard check to be more resilient and explicit

### DIFF
--- a/src/Goerli-DssSpell.t.base.sol
+++ b/src/Goerli-DssSpell.t.base.sol
@@ -1114,13 +1114,14 @@ contract GoerliDssSpellTestBase is Config, DSTest, DSMath {
     // ONLY ON GOERLI
     function skipWards(address target, address deployer) internal view returns (bool ok) {
         ok = (
-            target   == address(chainLog) &&
-            deployer == deployers.addr(2) ||
-            deployer == deployers.addr(3) ||
-            deployer == deployers.addr(4)
+            target   == address(chainLog)      &&
+            deployer == deployers.PE_03()      ||
+            deployer == deployers.PE_04()      ||
+            deployer == deployers.PE_05()      ||
+            deployer == deployers.PE_CURRENT()
         ) ||
         (
-            deployer == deployers.addr(6)  // Oracles
+            deployer == deployers.ORACLES()
         );
     }
 

--- a/src/test/addresses_deployers.sol
+++ b/src/test/addresses_deployers.sol
@@ -20,19 +20,33 @@ contract Deployers {
 
     address[] public addr;
 
+    // Skip Ward Deployers see Goerli-DssSpell.t.base.sol#skipWards(address,address)
+    address public constant PE_01       = 0xda0fab060e6cc7b1C0AA105d29Bd50D71f036711;
+    address public constant PE_02       = 0xDA0FaB0700A4389F6E6679aBAb1692B4601ce9bf;
+    address public constant PE_03       = 0xdA0C0de01d90A5933692Edf03c7cE946C7c50445;
+    address public constant PE_04       = 0xdB33dFD3D61308C33C63209845DaD3e6bfb2c674;
+    address public constant PE_05       = 0xDA01018eA05D98aBb66cb21a85d6019a311570eE;
+    address public constant PE_CURRENT  = 0xDa0c0De020F80d43dde58c2653aa73d28Df1fBe1;
+    address public constant ORACLES     = 0x1f42e41A34B71606FcC60b4e624243b365D99745;
+
+    // Known Team Deployers
+    address public constant CES         = 0x9956fca5a8994737f124c481cEDC6BB3dc5BF010;
+    address public constant STARKNET_01 = 0x8aa7c51A6D380F4d9E273adD4298D913416031Ec;
+    address public constant STARKNET_02 = 0x38F8e3b67FA8329FE4BaA1775e5480807f78887B;
+
     constructor() public {
         addr = [
-            0xda0fab060e6cc7b1C0AA105d29Bd50D71f036711,
-            0xDA0FaB0700A4389F6E6679aBAb1692B4601ce9bf,
-            0xdA0C0de01d90A5933692Edf03c7cE946C7c50445,  // Old PE
-            0xdB33dFD3D61308C33C63209845DaD3e6bfb2c674,
-            0xDA01018eA05D98aBb66cb21a85d6019a311570eE,
+            PE_01,
+            PE_02,
+            PE_03,
+            PE_04,
+            PE_05,
+            PE_CURRENT,
             0xDA0111100cb6080b43926253AB88bE719C60Be13,
-            0x1f42e41A34B71606FcC60b4e624243b365D99745,  // Oracles
-            0x8aa7c51A6D380F4d9E273adD4298D913416031Ec,  // Starknet
-            0x38F8e3b67FA8329FE4BaA1775e5480807f78887B,  // Starknet
-            0x9956fca5a8994737f124c481cEDC6BB3dc5BF010,  // CES
-            0xDa0c0De020F80d43dde58c2653aa73d28Df1fBe1   // New PE
+            ORACLES,
+            STARKNET_01,
+            STARKNET_02,
+            CES
         ];
     }
 


### PR DESCRIPTION
# Description

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in Goerli changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell to Goerli `ETH_GAS="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Ensure contract is verified on `Goerli` etherscan
- [ ] Change test to use Goerli spell address and deploy timestamp
- [ ] Cast spell on Goerli `make spell="0x-deployed-spell-address" cast-spell`
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `Goerli-DssSpell.sol`, `Goerli-DssSpell.t.sol`, `Goerli-DssSpell.t.base.sol`, and `Goerli-DssSpellCollateralOnboarding.sol`
- [ ] `squash and merge` this PR
