### PR TITLE
Add Teleport feed update to PE-1084

### DIFF
--- a/src/Goerli-DssSpell.sol
+++ b/src/Goerli-DssSpell.sol
@@ -23,6 +23,11 @@ import "dss-exec-lib/DssAction.sol";
 
 import { DssSpellCollateralAction } from "./Goerli-DssSpellCollateral.sol";
 
+interface TeleportOracleAuthLike {
+    function addSigners(address[] calldata) external;
+    function removeSigners(address[] calldata) external;
+}
+
 contract DssSpellAction is DssAction, DssSpellCollateralAction {
 
     // Provides a descriptive tag for bot consumption
@@ -47,6 +52,28 @@ contract DssSpellAction is DssAction, DssSpellCollateralAction {
         // Includes changes from the DssSpellCollateralAction
         // onboardNewCollaterals();
         // offboardCollaterals();
+
+
+
+        // ------------------ Update Teleport Feeds ----------------- 
+        TeleportOracleAuthLike teleportOracleAuth = TeleportOracleAuthLike(DssExecLib.getChangelogAddress("MCD_ORACLE_AUTH_TELEPORT_FW_A"));
+        address[] memory feedsToRemove = new address[](9);
+        feedsToRemove[0] = 0x0E0cDcbbE170f6d81f87b45c2227526B6779A083;
+        feedsToRemove[1] = 0x73093A55d5703C7A81D7381F7F24FCf432c64652;
+        feedsToRemove[2] = 0x2a2b83700c990FDFEFD22968fc7C4A4B80783E60;
+        feedsToRemove[3] = 0x1BC7410DD4D18bf8f613F4B6a646FA3953D3A0f2;
+        feedsToRemove[4] = 0xE5D5b00cc04596461a5527616b4F88B754879aE8;
+        feedsToRemove[5] = 0xA5E6053Fe351883036d13C2219b68102AbdFcBB6;
+        feedsToRemove[6] = 0x59524b843866b9686c520fB3d3613A73fe303d30;
+        feedsToRemove[7] = 0x794D810a3d524B9E25227bFA22E69CaaC8544EF2;
+        feedsToRemove[8] = 0xE85963ACc9A361E13306c6395186aa950f750883;
+        teleportOracleAuth.removeSigners(feedsToRemove);
+        address[] memory feedsToAdd = new address[](4);
+        feedsToAdd[0] = 0x0c4FC7D66b7b6c684488c1F218caA18D4082da18;
+        feedsToAdd[1] = 0x5C01f0F08E54B85f4CaB8C6a03c9425196fe66DD;
+        feedsToAdd[2] = 0xC50DF8b5dcb701aBc0D6d1C7C99E6602171Abbc4;
+        feedsToAdd[3] = 0x75FBD0aaCe74Fb05ef0F6C0AC63d26071Eb750c9;
+        teleportOracleAuth.addSigners(feedsToAdd);
     }
 }
 

--- a/src/Goerli-DssSpell.sol
+++ b/src/Goerli-DssSpell.sol
@@ -53,8 +53,6 @@ contract DssSpellAction is DssAction, DssSpellCollateralAction {
         // onboardNewCollaterals();
         // offboardCollaterals();
 
-
-
         // ------------------ Update Teleport Feeds ----------------- 
         TeleportOracleAuthLike teleportOracleAuth = TeleportOracleAuthLike(DssExecLib.getChangelogAddress("MCD_ORACLE_AUTH_TELEPORT_FW_A"));
         address[] memory feedsToRemove = new address[](9);

--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -486,6 +486,10 @@ contract DssSpellTest is GoerliDssSpellTestBase {
     }
 
      function testUpdateTeleportFeeds() public {
+        vote(address(spell));
+        scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
         TeleportOracleAuthLike oracleAuth = TeleportOracleAuthLike(addr.addr("MCD_ORACLE_AUTH_TELEPORT_FW_A"));
 
         // old feeds that were kept

--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -486,11 +486,26 @@ contract DssSpellTest is GoerliDssSpellTestBase {
     }
 
      function testUpdateTeleportFeeds() public {
+        TeleportOracleAuthLike oracleAuth = TeleportOracleAuthLike(addr.addr("MCD_ORACLE_AUTH_TELEPORT_FW_A"));
+
+        assertEq(oracleAuth.signers(0xC4756A9DaE297A046556261Fa3CD922DFC32Db78), 1);
+        assertEq(oracleAuth.signers(0x23ce419DcE1De6b3647Ca2484A25F595132DfBd2), 1);
+        assertEq(oracleAuth.signers(0x774D5AA0EeE4897a9a6e65Cbed845C13Ffbc6d16), 1);
+        assertEq(oracleAuth.signers(0xb41E8d40b7aC4Eb34064E079C8Eca9d7570EBa1d), 1);
+        assertEq(oracleAuth.signers(0x0E0cDcbbE170f6d81f87b45c2227526B6779A083), 1);
+        assertEq(oracleAuth.signers(0x73093A55d5703C7A81D7381F7F24FCf432c64652), 1);
+        assertEq(oracleAuth.signers(0x2a2b83700c990FDFEFD22968fc7C4A4B80783E60), 1);
+        assertEq(oracleAuth.signers(0x1BC7410DD4D18bf8f613F4B6a646FA3953D3A0f2), 1);
+        assertEq(oracleAuth.signers(0xE5D5b00cc04596461a5527616b4F88B754879aE8), 1);
+        assertEq(oracleAuth.signers(0xA5E6053Fe351883036d13C2219b68102AbdFcBB6), 1);
+        assertEq(oracleAuth.signers(0x59524b843866b9686c520fB3d3613A73fe303d30), 1);
+        assertEq(oracleAuth.signers(0x794D810a3d524B9E25227bFA22E69CaaC8544EF2), 1);
+        assertEq(oracleAuth.signers(0xE85963ACc9A361E13306c6395186aa950f750883), 1);
+        assertEq(oracleAuth.signers(0xc65EF2D17B05ADbd8e4968bCB01b325ab799aBd8), 1);
+
         vote(address(spell));
         scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
-
-        TeleportOracleAuthLike oracleAuth = TeleportOracleAuthLike(addr.addr("MCD_ORACLE_AUTH_TELEPORT_FW_A"));
 
         // old feeds that were kept
         assertEq(oracleAuth.signers(0xC4756A9DaE297A046556261Fa3CD922DFC32Db78), 1);

--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -484,4 +484,32 @@ contract DssSpellTest is GoerliDssSpellTestBase {
         assertTrue(tauOld == tauNew, "tau is the same");
         assertTrue(tocOld == tocNew, "toc is the same");
     }
+
+     function testUpdateTeleportFeeds() public {
+        TeleportOracleAuthLike oracleAuth = TeleportOracleAuthLike(addr.addr("MCD_ORACLE_AUTH_TELEPORT_FW_A"));
+
+        // old feeds that were kept
+        assertEq(oracleAuth.signers(0xC4756A9DaE297A046556261Fa3CD922DFC32Db78), 1);
+        assertEq(oracleAuth.signers(0x23ce419DcE1De6b3647Ca2484A25F595132DfBd2), 1);
+        assertEq(oracleAuth.signers(0x774D5AA0EeE4897a9a6e65Cbed845C13Ffbc6d16), 1);
+        assertEq(oracleAuth.signers(0xb41E8d40b7aC4Eb34064E079C8Eca9d7570EBa1d), 1);
+        assertEq(oracleAuth.signers(0xc65EF2D17B05ADbd8e4968bCB01b325ab799aBd8), 1);
+
+        // newly added feeds
+        assertEq(oracleAuth.signers(0x0c4FC7D66b7b6c684488c1F218caA18D4082da18), 1);
+        assertEq(oracleAuth.signers(0x5C01f0F08E54B85f4CaB8C6a03c9425196fe66DD), 1);
+        assertEq(oracleAuth.signers(0xC50DF8b5dcb701aBc0D6d1C7C99E6602171Abbc4), 1);
+        assertEq(oracleAuth.signers(0x75FBD0aaCe74Fb05ef0F6C0AC63d26071Eb750c9), 1);
+
+        // old feeds that were removed
+        assertEq(oracleAuth.signers(0x0E0cDcbbE170f6d81f87b45c2227526B6779A083), 0);
+        assertEq(oracleAuth.signers(0x73093A55d5703C7A81D7381F7F24FCf432c64652), 0);
+        assertEq(oracleAuth.signers(0x2a2b83700c990FDFEFD22968fc7C4A4B80783E60), 0);
+        assertEq(oracleAuth.signers(0x1BC7410DD4D18bf8f613F4B6a646FA3953D3A0f2), 0);
+        assertEq(oracleAuth.signers(0xE5D5b00cc04596461a5527616b4F88B754879aE8), 0);
+        assertEq(oracleAuth.signers(0xA5E6053Fe351883036d13C2219b68102AbdFcBB6), 0);
+        assertEq(oracleAuth.signers(0x59524b843866b9686c520fB3d3613A73fe303d30), 0);
+        assertEq(oracleAuth.signers(0x794D810a3d524B9E25227bFA22E69CaaC8544EF2), 0);
+        assertEq(oracleAuth.signers(0xE85963ACc9A361E13306c6395186aa950f750883), 0);
+    }
 }


### PR DESCRIPTION
# Description

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in Goerli changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell to Goerli `ETH_GAS="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Ensure contract is verified on `Goerli` etherscan
- [ ] Change test to use Goerli spell address and deploy timestamp
- [ ] Cast spell on Goerli `make spell="0x-deployed-spell-address" cast-spell`
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `Goerli-DssSpell.sol`, `Goerli-DssSpell.t.sol`, `Goerli-DssSpell.t.base.sol`, and `Goerli-DssSpellCollateralOnboarding.sol`
- [ ] `squash and merge` this PR
