### PR TITLE
PE-1102: 2022-10-19 Executive GUSD PSM

### DIFF
--- a/src/Goerli-DssSpell.sol
+++ b/src/Goerli-DssSpell.sol
@@ -45,7 +45,8 @@ contract DssSpellAction is DssAction, DssSpellCollateralAction {
     // uint256 constant THREE_PCT_RATE          = 1000000000937303470807876289;
 
     // --- Math ---
-    // uint256 internal constant MILLION = 10 ** 6;
+    uint256 internal constant WAD     = 10 ** 18;
+    uint256 internal constant MILLION = 10 **  6;
 
 
 
@@ -54,6 +55,18 @@ contract DssSpellAction is DssAction, DssSpellCollateralAction {
         // Includes changes from the DssSpellCollateralAction
         // onboardCollaterals();
         // offboardCollaterals();
+
+        // ---------------------------------------------------------------------
+        // Vote: https://vote.makerdao.com/polling/QmYffkvR#poll-detail
+        // Forum: https://forum.makerdao.com/t/signal-request-change-psm-gusd-a-parameters/18142
+        address MCD_PSM_GUSD_A = DssExecLib.getChangelogAddress("MCD_PSM_GUSD_A");
+        DssExecLib.setIlkAutoLineParameters({
+            _ilk:    "PSM-GUSD-A",
+            _amount: 500 * MILLION,
+            _gap:    50 * MILLION,
+            _ttl:    24 hours
+        });
+        DssExecLib.setValue(MCD_PSM_GUSD_A, "tout", 2 * WAD / 1000);
     }
 }
 

--- a/src/Goerli-DssSpell.sol
+++ b/src/Goerli-DssSpell.sol
@@ -46,9 +46,6 @@ contract DssSpellAction is DssAction, DssSpellCollateralAction {
 
     // --- Math ---
     uint256 internal constant WAD     = 10 ** 18;
-    uint256 internal constant MILLION = 10 **  6;
-
-
 
     function actions() public override {
         // ---------------------------------------------------------------------

--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -20,7 +20,10 @@ import "./Goerli-DssSpell.t.base.sol";
 
 interface DssExecLike {
     function action() external returns (address);
+}
 
+interface DssPsmLike {
+    function tout() external view returns (uint256);
 }
 
 contract DssSpellTest is GoerliDssSpellTestBase {
@@ -113,6 +116,17 @@ contract DssSpellTest is GoerliDssSpellTestBase {
         checkSystemValues(afterSpell);
 
         checkCollateralValues(afterSpell);
+    }
+
+    function testSpellIsCast_PSM_GUSD_A_tout() public {
+        DssPsmLike psmPSMGUSD = DssPsmLike(addr.addr("MCD_PSM_GUSD_A"));
+        assertEq(psmPSMGUSD.tout(), 0);
+
+        vote(address(spell));
+        scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        assertEq(psmPSMGUSD.tout(), 2000000000000000);
     }
 
     function testRemoveChainlogValues() private { // make public to use

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -1641,8 +1641,8 @@ contract Config {
 //        });
         afterSpell.collaterals["PSM-GUSD-A"] = CollateralValues({
             aL_enabled:   true,
-            aL_line:      60 * MILLION,
-            aL_gap:       10 * MILLION,
+            aL_line:      500 * MILLION,
+            aL_gap:       50 * MILLION,
             aL_ttl:       24 hours,
             line:         0,
             dust:         0,


### PR DESCRIPTION
Changes for the PE-1102 Spell that concern the **GUSD PSM**
https://vote.makerdao.com/polling/QmYffkvR#vote-breakdown
https://forum.makerdao.com/t/signal-request-change-psm-gusd-a-parameters/18142

- [ ] Increase tout from 0 to 20bps
- [ ] Increases Maximum Debt Ceiling (line) from 60 million DAI to 500 million DAI
- [ ] Increase Target Available Debt (gap) from 10 million DAI to 50 million DAI

