### PR TITLE
Multichain spells

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/dss-exec-lib"]
 	path = lib/dss-exec-lib
 	url = https://github.com/makerdao/dss-exec-lib
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,9 @@
 [submodule "lib/dss-interfaces"]
 	path = lib/dss-interfaces
 	url = https://github.com/makerdao/dss-interfaces
-[submodule "lib/dss-exec-lib"]
-	path = lib/dss-exec-lib
-	url = https://github.com/makerdao/dss-exec-lib
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/dss-exec-lib"]
+	path = lib/dss-exec-lib
+	url = https://github.com/makerdao/dss-exec-lib

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all                :; DAPP_LIBRARIES=' lib/dss-exec-lib/src/DssExecLib.sol:DssEx
 clean              :; dapp clean
                       # Usage example: make test match=SpellIsCast
 test               :; ./scripts/test-dssspell.sh match="$(match)" optimizer="$(optimizer)" optimizer-runs="$(optimizer-runs)" block="$(block)"
-test-forge         :; ./scripts/test-dssspell-forge.sh match="$(match)" block="$(block)"
+test-forge         :; ./scripts/test-dssspell-forge.sh match="$(match)" block="$(block)" opt-block="$(opt-block)" arb-block="$(arb-block)"
 estimate           :; ./scripts/estimate-deploy-gas.sh
 deploy             :; ./scripts/deploy.sh
 deploy-stamp       :; ./scripts/get-created-timestamp.sh tx=$(tx)

--- a/config/domains.json
+++ b/config/domains.json
@@ -1,0 +1,17 @@
+{
+    "domains": {
+        "root": {
+            "rpc": "ETH_RPC_URL",
+            "chainlog": "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F",
+            "block": "ROOT_BLOCK"
+        },
+        "optimism": {
+            "rpc": "OPT_RPC_URL",
+            "block": "OPT_BLOCK"
+        },
+        "arbitrum": {
+            "rpc": "ARB_RPC_URL",
+            "block": "ARB_BLOCK"
+        }
+    }
+}

--- a/config/domains.json
+++ b/config/domains.json
@@ -1,9 +1,7 @@
 {
     "domains": {
         "root": {
-            "rpc": "ETH_RPC_URL",
-            "chainlog": "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F",
-            "block": "ROOT_BLOCK"
+            "chainlog": "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F"
         },
         "optimism": {
             "rpc": "OPT_RPC_URL",

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+fs_permissions = [
+    { access = "read", path = "./config/domains.json"},
+]

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -26,11 +26,11 @@ export ARB_BLOCK=0
 if [[ -z "$MATCH" && -z "$BLOCK" ]]; then
     forge test --force
 elif [[ -z "$BLOCK" ]]; then
-    forge test --match "$MATCH" -vvvvv --force
+    forge test --match "$MATCH" -vvv --force
 elif [[ -z "$MATCH" ]]; then
     export ROOT_BLOCK=$BLOCK
     forge test -vvv --force
 else
     export ROOT_BLOCK=$BLOCK
-    forge test --match "$MATCH" -vvvvv --force
+    forge test --match "$MATCH" -vvv --force
 fi

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -19,13 +19,18 @@ DSS_EXEC_LIB=$(< DssExecLib.address)
 echo "Using DssExecLib at: $DSS_EXEC_LIB"
 export DAPP_LIBRARIES="src/DssSpell.sol:DssExecLib:$DSS_EXEC_LIB"
 export DAPP_BUILD_OPTIMIZE=0   # forge turns on optimizer by default
+export ROOT_BLOCK=0
+export OPT_BLOCK=0
+export ARB_BLOCK=0
 
 if [[ -z "$MATCH" && -z "$BLOCK" ]]; then
-    forge test --fork-url "$ETH_RPC_URL" --force
+    forge test --force
 elif [[ -z "$BLOCK" ]]; then
-    forge test --fork-url "$ETH_RPC_URL" --match "$MATCH" -vvv --force
+    forge test --match "$MATCH" -vvvvv --force
 elif [[ -z "$MATCH" ]]; then
-    forge test --fork-url "$ETH_RPC_URL" --fork-block-number "$BLOCK" --force
+    export ROOT_BLOCK=$BLOCK
+    forge test -vvv --force
 else
-    forge test --fork-url "$ETH_RPC_URL" --match "$MATCH" --fork-block-number "$BLOCK" -vvv --force
+    export ROOT_BLOCK=$BLOCK
+    forge test --match "$MATCH" -vvvvv --force
 fi

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -11,6 +11,8 @@ do
     case "$KEY" in
             match)      MATCH="$VALUE" ;;
             block)      BLOCK="$VALUE" ;;
+            opt-block)   OPT_BLOCK="$VALUE" ;;
+            arb-block)   ARB_BLOCK="$VALUE" ;;
             *)
     esac
 done
@@ -19,18 +21,37 @@ DSS_EXEC_LIB=$(< DssExecLib.address)
 echo "Using DssExecLib at: $DSS_EXEC_LIB"
 export DAPP_LIBRARIES="src/DssSpell.sol:DssExecLib:$DSS_EXEC_LIB"
 export DAPP_BUILD_OPTIMIZE=0   # forge turns on optimizer by default
-export ROOT_BLOCK=0
-export OPT_BLOCK=0
-export ARB_BLOCK=0
+
+# L2 setup
+
+if [[ -z "$OPT_RPC_URL" ]]; then
+    echo "OPTIMISM not used"
+    export OPT_RPC_URL=""
+fi
+
+if [[ -z "$ARB_RPC_URL" ]]; then
+    echo "ARBITRUM not used"
+    export ARB_RPC_URL=""
+fi
+
+if [[ -z "$OPT_BLOCK" ]]; then
+    export OPT_BLOCK=0
+else
+    export OPT_BLOCK=$OPT_BLOCK
+fi
+
+if [[ -z "$OPT_BLOCK" ]]; then
+    export ARB_BLOCK=0
+else
+    export ARB_BLOCK=$ARB_BLOCK
+fi
 
 if [[ -z "$MATCH" && -z "$BLOCK" ]]; then
-    forge test --force
+    forge test --fork-url "$ETH_RPC_URL" --force
 elif [[ -z "$BLOCK" ]]; then
-    forge test --match "$MATCH" -vvv --force
+    forge test --fork-url "$ETH_RPC_URL" --match "$MATCH" -vvv --force
 elif [[ -z "$MATCH" ]]; then
-    export ROOT_BLOCK=$BLOCK
-    forge test -vvv --force
+    forge test --fork-url "$ETH_RPC_URL" --fork-block-number "$BLOCK" --force
 else
-    export ROOT_BLOCK=$BLOCK
-    forge test --match "$MATCH" -vvv --force
+    forge test --fork-url "$ETH_RPC_URL" --match "$MATCH" --fork-block-number "$BLOCK" -vvv --force
 fi

--- a/src/Goerli-DssSpell.t.base.sol
+++ b/src/Goerli-DssSpell.t.base.sol
@@ -18,7 +18,7 @@ pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "ds-math/math.sol";
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "dss-interfaces/Interfaces.sol";
 
 import "./test/rates.sol";
@@ -139,7 +139,7 @@ interface ArbitrumTeleportBridgeLike is TeleportBridgeLike {
     function inbox() external view returns (address);
 }
 
-contract GoerliDssSpellTestBase is Config, DSTest, DSMath {
+contract GoerliDssSpellTestBase is Config, Test, DSMath {
     Hevm hevm;
 
     Rates         rates = new Rates();

--- a/src/Goerli-DssSpell.t.base.sol
+++ b/src/Goerli-DssSpell.t.base.sol
@@ -311,7 +311,6 @@ contract GoerliDssSpellTestBase is Config, Test, DSMath {
         rootDomain = new Domain(vm, config, "root");
         optimismDomain = new Domain(vm, config, "optimism");
         rootDomain.selectFork();
-        rootDomain.rollFork();
 
         setValues(address(chief));
 

--- a/src/Goerli-DssSpell.t.base.sol
+++ b/src/Goerli-DssSpell.t.base.sol
@@ -137,7 +137,7 @@ contract GoerliDssSpellTestBase is Config, Test, DSMath {
     string config;
     Domain rootDomain;
     Domain optimismDomain;
-    Domain arbitrumFork;
+    Domain arbitrumDomain;
 
     Rates         rates = new Rates();
     Addresses      addr = new Addresses();
@@ -309,24 +309,17 @@ contract GoerliDssSpellTestBase is Config, Test, DSMath {
         rootDomain = new Domain(vm, config, "root");
         // This should be set from the forge test script
         rootDomain.loadFork(vm.activeFork());
+        assertEq(vm.activeFork(), 0);
 
         // Load optimism from config
         optimismDomain = new Domain(vm, config, "optimism");
+        // Loads config and rolls to block set with opt-block
         optimismDomain.loadConfig();
-        assertEq(vm.activeFork(), 0);
-        assertEq(block.number, 7838100);
 
-        if (optimismDomain.live() == 1) {
-            optimismDomain.selectFork();
-            assertEq(vm.activeFork(), 1);
-            assertEq(block.number, 2437710, "wrong optimism block");
-            optimismDomain.rollFork(2437710 + 10);
-            assertEq(block.number, 2437720, "wrong optimism block");
-
-            rootDomain.selectFork();
-            assertEq(vm.activeFork(), 0);
-            assertEq(block.number, 7838100);
-        }
+        // Load arbitrum from config
+        arbitrumDomain = new Domain(vm, config, "arbitrum");
+        // Loads config and rolls to block set with arb-block
+        arbitrumDomain.loadConfig();
     }
 
 

--- a/src/Goerli-DssSpell.t.sol
+++ b/src/Goerli-DssSpell.t.sol
@@ -173,11 +173,11 @@ contract DssSpellTest is GoerliDssSpellTestBase {
         LerpAbstract lerp = LerpAbstract(lerpFactory.lerps("NAME"));
 
         uint256 duration = 210 days;
-        hevm.warp(block.timestamp + duration / 2);
+        vm.warp(block.timestamp + duration / 2);
         assertEq(vow.hump(), 60 * MILLION * RAD);
         lerp.tick();
         assertEq(vow.hump(), 75 * MILLION * RAD);
-        hevm.warp(block.timestamp + duration / 2);
+        vm.warp(block.timestamp + duration / 2);
         lerp.tick();
         assertEq(vow.hump(), 90 * MILLION * RAD);
         assertTrue(lerp.done());
@@ -254,7 +254,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
         spell.schedule();
 
         castPreviousSpell();
-        hevm.warp(spell.nextCastTime());
+        vm.warp(spell.nextCastTime());
         uint256 startGas = gasleft();
         spell.cast();
         uint256 endGas = gasleft();
@@ -267,7 +267,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
 
     // The specific date doesn't matter that much since function is checking for difference between warps
     function test_nextCastTime() public {
-        hevm.warp(1606161600); // Nov 23, 20 UTC (could be cast Nov 26)
+        vm.warp(1606161600); // Nov 23, 20 UTC (could be cast Nov 26)
 
         vote(address(spell));
         spell.schedule();
@@ -276,29 +276,29 @@ contract DssSpellTest is GoerliDssSpellTestBase {
         uint256 monday_2100_UTC = 1606770000; // Nov 30, 2020
 
         // Day tests
-        hevm.warp(monday_1400_UTC);                                    // Monday,   14:00 UTC
+        vm.warp(monday_1400_UTC);                                    // Monday,   14:00 UTC
         assertEq(spell.nextCastTime(), monday_1400_UTC);               // Monday,   14:00 UTC
 
         if (spell.officeHours()) {
-            hevm.warp(monday_1400_UTC - 1 days);                       // Sunday,   14:00 UTC
+            vm.warp(monday_1400_UTC - 1 days);                       // Sunday,   14:00 UTC
             assertEq(spell.nextCastTime(), monday_1400_UTC);           // Monday,   14:00 UTC
 
-            hevm.warp(monday_1400_UTC - 2 days);                       // Saturday, 14:00 UTC
+            vm.warp(monday_1400_UTC - 2 days);                       // Saturday, 14:00 UTC
             assertEq(spell.nextCastTime(), monday_1400_UTC);           // Monday,   14:00 UTC
 
-            hevm.warp(monday_1400_UTC - 3 days);                       // Friday,   14:00 UTC
+            vm.warp(monday_1400_UTC - 3 days);                       // Friday,   14:00 UTC
             assertEq(spell.nextCastTime(), monday_1400_UTC - 3 days);  // Able to cast
 
-            hevm.warp(monday_2100_UTC);                                // Monday,   21:00 UTC
+            vm.warp(monday_2100_UTC);                                // Monday,   21:00 UTC
             assertEq(spell.nextCastTime(), monday_1400_UTC + 1 days);  // Tuesday,  14:00 UTC
 
-            hevm.warp(monday_2100_UTC - 1 days);                       // Sunday,   21:00 UTC
+            vm.warp(monday_2100_UTC - 1 days);                       // Sunday,   21:00 UTC
             assertEq(spell.nextCastTime(), monday_1400_UTC);           // Monday,   14:00 UTC
 
-            hevm.warp(monday_2100_UTC - 2 days);                       // Saturday, 21:00 UTC
+            vm.warp(monday_2100_UTC - 2 days);                       // Saturday, 21:00 UTC
             assertEq(spell.nextCastTime(), monday_1400_UTC);           // Monday,   14:00 UTC
 
-            hevm.warp(monday_2100_UTC - 3 days);                       // Friday,   21:00 UTC
+            vm.warp(monday_2100_UTC - 3 days);                       // Friday,   21:00 UTC
             assertEq(spell.nextCastTime(), monday_1400_UTC);           // Monday,   14:00 UTC
 
             // Time tests
@@ -306,10 +306,10 @@ contract DssSpellTest is GoerliDssSpellTestBase {
 
             for(uint256 i = 0; i < 5; i++) {
                 castTime = monday_1400_UTC + i * 1 days; // Next day at 14:00 UTC
-                hevm.warp(castTime - 1 seconds); // 13:59:59 UTC
+                vm.warp(castTime - 1 seconds); // 13:59:59 UTC
                 assertEq(spell.nextCastTime(), castTime);
 
-                hevm.warp(castTime + 7 hours + 1 seconds); // 21:00:01 UTC
+                vm.warp(castTime + 7 hours + 1 seconds); // 21:00:01 UTC
                 if (i < 4) {
                     assertEq(spell.nextCastTime(), monday_1400_UTC + (i + 1) * 1 days); // Next day at 14:00 UTC
                 } else {
@@ -324,7 +324,7 @@ contract DssSpellTest is GoerliDssSpellTestBase {
     }
 
     function test_use_eta() public {
-        hevm.warp(1606161600); // Nov 23, 20 UTC (could be cast Nov 26)
+        vm.warp(1606161600); // Nov 23, 20 UTC (could be cast Nov 26)
 
         vote(address(spell));
         spell.schedule();

--- a/src/test/addresses_deployers.sol
+++ b/src/test/addresses_deployers.sol
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.6.12;
+pragma solidity 0.6.12;
 
 contract Deployers {
 

--- a/src/test/addresses_deployers.sol
+++ b/src/test/addresses_deployers.sol
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity 0.6.12;
+pragma solidity ^0.6.12;
 
 contract Deployers {
 

--- a/src/test/addresses_goerli.sol
+++ b/src/test/addresses_goerli.sol
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity 0.6.12;
+pragma solidity ^0.6.12;
 
 contract Addresses {
 

--- a/src/test/addresses_goerli.sol
+++ b/src/test/addresses_goerli.sol
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.6.12;
+pragma solidity 0.6.12;
 
 contract Addresses {
 

--- a/src/test/domains/Domain.sol
+++ b/src/test/domains/Domain.sol
@@ -38,6 +38,10 @@ contract Domain {
         string memory rpc = vm.envString(readConfigString("rpc"));
         if (bytes(rpc).length == 0) revert(stringConcat(stringConcat("Environment variable '", rpc), "' is not defined."));
         forkId = vm.createFork(rpc);
+        uint256 domainBlock = vm.envUint(readConfigString("block"));
+        if (domainBlock > 0) {
+            vm.rollFork(forkId, domainBlock);
+        }
         vm.makePersistent(address(this));
     }
 
@@ -67,12 +71,5 @@ contract Domain {
 
     function selectFork() public {
         vm.selectFork(forkId);
-    }
-
-    function rollFork() public {
-        uint256 domainBlock = vm.envUint(readConfigString("block"));
-        if (domainBlock > 0) {
-            vm.rollFork(domainBlock);
-        }
     }
 }

--- a/src/test/domains/Domain.sol
+++ b/src/test/domains/Domain.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity 0.6.12;
+
+import {stdJson} from "forge-std/StdJson.sol";
+import {ChainlogAbstract} from "dss-interfaces/Interfaces.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+contract Domain {
+
+    using stdJson for string;
+
+    string public config;
+    string public name;
+    Vm public vm;
+    uint256 public forkId;
+
+    event Log(string, string);
+    event Log(string, uint256);
+
+    constructor(Vm _vm, string memory _config, string memory _name) public {
+        config = _config;
+        name = _name;
+        vm = _vm;
+        string memory rpc = vm.envString(readConfigString("rpc"));
+        if (bytes(rpc).length == 0) revert(stringConcat(stringConcat("Environment variable '", rpc), "' is not defined."));
+        forkId = vm.createFork(rpc);
+        vm.makePersistent(address(this));
+    }
+
+    function stringConcat(string memory a, string memory b) pure internal returns(string memory) {
+        return string(abi.encodePacked(a, b));
+    }
+
+    function readConfigString(string memory key) public returns (string memory) {
+        return config.readString(stringConcat(stringConcat(stringConcat(".domains.", name), "."), key));
+    }
+
+    function readConfigAddress(string memory key) public returns (address) {
+        return config.readAddress(stringConcat(stringConcat(stringConcat(".domains.", name), "."), key));
+    }
+
+    function readConfigUint(string memory key) public returns (uint256) {
+        return config.readUint(stringConcat(stringConcat(stringConcat(".domains.", name), "."), key));
+    }
+
+    function readConfigInt(string memory key) public returns (int256) {
+        return config.readInt(stringConcat(stringConcat(stringConcat(".domains.", name), "."), key));
+    }
+
+    function readConfigBytes32(string memory key) public returns (bytes32) {
+        return config.readBytes32(stringConcat(stringConcat(stringConcat(".domains.", name), "."), key));
+    }
+
+    function selectFork() public {
+        vm.selectFork(forkId);
+    }
+
+    function rollFork() public {
+        uint256 domainBlock = vm.envUint(readConfigString("block"));
+        if (domainBlock > 0) {
+            vm.rollFork(domainBlock);
+        }
+    }
+}


### PR DESCRIPTION
# Description

This is the initial base PR for adding multichain support to the spells repo. It updates the forge test script and adds necessary config files to be able to **optionally** connect to optimism or arbitrum domains.  This will allow future development to add tests for specific values on the L2s or testing the effects of cross chain spells.

To connect to optimism or arbitrum when running tests you should export `OPT_RPC_URL` or `ARB_RPC_URL` along with your goerli `ETH_RPC_URL`.  Forge will load Goerli as a fork from your `ETH_RPC_URL`.  If you pass `arb-block` or `opt-block` into your `make test-forge` command (i.e. `make test-forge block=<GOERLI-BLOCK> opt-block=<OPTIMISM-BLOCK> arb-block=<ARBITRUM-BLOCK>`) your forks will be rolled to those specific blocks for testing the state/effects at that point in time.

## Note: this is a breaking change for `dapp` 

As we have to use cheatcodes (i.e. `vm.makePersistent`) that will not work for our `make test` command. As such this should probably go in after https://github.com/makerdao/spells-goerli/pull/130