### PR TITLE
Port test of deploy size and update to deploycost test

### DIFF
--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -318,8 +318,38 @@ contract DssSpellTest is GoerliDssSpellTestBase {
         new DssSpell();
         uint256 endGas = gasleft();
         uint256 totalGas = startGas - endGas;
+
+        // Warn if deploy exceeds block target size
+        if (totalGas > 15 * MILLION) {
+            emit log("Warn: deploy gas exceeds average block target");
+            emit log_named_uint("    deploy gas", totalGas);
+            emit log_named_uint("  block target", 15 * MILLION);
+        }
+
         // Fail if deploy is too expensive
-        assertLe(totalGas, 15 * MILLION);
+        assertLe(totalGas, 30 * MILLION, "testDeployCost/DssSpell-exceeds-max-block-size");
+    }
+
+
+    // Fail when contract code size exceeds 24576 bytes (a limit introduced in Spurious Dragon).
+    // This contract may not be deployable.
+    // Consider enabling the optimizer (with a low "runs" value!),
+    //   turning off revert strings, or using libraries.
+    function testContractSize() public {
+        uint256 _sizeSpell;
+        address _spellAddr  = address(spell);
+        assembly {
+            _sizeSpell := extcodesize(_spellAddr)
+        }
+        assertLe(_sizeSpell, 24576, "testContractSize/DssSpell-exceeds-max-contract-size");
+
+        uint256 _sizeAction;
+        address _actionAddr = spell.action();
+        assembly {
+            _sizeAction := extcodesize(_actionAddr)
+        }
+        assertLe(_sizeAction, 24576, "testContractSize/DssSpellAction-exceeds-max-contract-size");
+
     }
 
     // The specific date doesn't matter that much since function is checking for difference between warps


### PR DESCRIPTION
# Description

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in Goerli changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell to Goerli `ETH_GAS="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Ensure contract is verified on `Goerli` etherscan
- [ ] Change test to use Goerli spell address and deploy timestamp
- [ ] Cast spell on Goerli `make spell="0x-deployed-spell-address" cast-spell`
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `DssSpell.sol`, `DssSpell.t.sol` and `DssSpell.t.base.sol`
- [ ] `squash and merge` this PR
