### PR TITLE
Pe 1184 add l2 tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,10 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+fs_permissions = [
+    { access = "read", path = "./script/input/"},
+    { access = "read", path = "./out/ArbitrumDomain.sol/ArbSysOverride.json"}
+]
+
+# See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/script/input/5/integration.json
+++ b/script/input/5/integration.json
@@ -1,0 +1,15 @@
+{
+    "domains": {
+        "goerli": {
+            "chainlog": "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F"
+        },
+        "optimism_goerli": {
+            "l1Messenger": "0x5086d1eEF304eb5284A0f6720f79403b4e9bE294",
+            "l2Messenger": "0x4200000000000000000000000000000000000007"
+        },
+        "arbitrum_one_goerli": {
+            "inbox": "0x6BEbC4925716945D46F0Ec336D5C2564F419682C",
+            "arbSys": "0x0000000000000000000000000000000000000064"
+        }
+    }
+}

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -20,6 +20,8 @@ echo "Using DssExecLib at: $DSS_EXEC_LIB"
 export FOUNDRY_LIBRARIES="lib/dss-exec-lib/src/DssExecLib.sol:DssExecLib:$DSS_EXEC_LIB"
 export FOUNDRY_OPTIMIZER=false
 export FOUNDRY_OPTIMIZER_RUNS=200
+export FOUNDRY_ROOT_CHAINID=5
+export GOERLI_RPC_URL="$ETH_RPC_URL"
 
 if [[ -z "$MATCH" && -z "$BLOCK" ]]; then
     forge test --fork-url "$ETH_RPC_URL"

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -79,15 +79,6 @@ contract DssSpellAction is DssAction {
     // uint256 internal constant RAY  = 10 ** 27;
     uint256 internal constant WAD     = 10 ** 18;
 
-    // ChainLogLike internal immutable CHAINLOG    = ChainLogLike(DssExecLib.getChangelogAddress("CHANGELOG"));
-
-    address internal immutable FLASH_KILLER     = DssExecLib.getChangelogAddress("FLASH_KILLER");
-    address internal immutable MCD_FLASH        = DssExecLib.getChangelogAddress("MCD_FLASH");
-    address internal immutable MCD_FLASH_LEGACY = DssExecLib.getChangelogAddress("MCD_FLASH_LEGACY");
-
-    address internal immutable MCD_PSM_PAX_A    = DssExecLib.getChangelogAddress("MCD_PSM_PAX_A");
-    address internal immutable MCD_PSM_GUSD_A   = DssExecLib.getChangelogAddress("MCD_PSM_GUSD_A");
-
     function actions() public override {
         // ------------------ Pause Optimism Goerli L2DaiTeleportGateway -----------------
         // Forum: https://forum.makerdao.com/t/community-notice-pecu-to-redeploy-teleport-l2-gateways/19550

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -17,7 +17,7 @@
 pragma solidity 0.8.16;
 
 import "dss-interfaces/Interfaces.sol";
-import {DssTest, GodMode} from "dss-test/DssTest.sol";
+import {DssTest, GodMode, ScriptTools} from "dss-test/DssTest.sol";
 
 import "./test/rates.sol";
 import "./test/addresses_goerli.sol";

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -18,7 +18,14 @@ pragma solidity 0.8.16;
 
 import "./DssSpell.t.base.sol";
 
+import {RootDomain} from "dss-test/domains/RootDomain.sol";
+import {OptimismDomain} from "dss-test/domains/OptimismDomain.sol";
+
 contract DssSpellTest is DssSpellTestBase {
+    string         config;
+    RootDomain     rootDomain;
+    OptimismDomain optimismDomain;
+
     // DO NOT TOUCH THE FOLLOWING TESTS, THEY SHOULD BE RUN ON EVERY SPELL
     function testGeneral() public {
         _testGeneral();
@@ -382,5 +389,18 @@ contract DssSpellTest is DssSpellTestBase {
 
         vm.expectRevert(abi.encodePacked("dss-chain-log/invalid-key"));
         chainLog.getAddress("FLASH_KILLER");
+    }
+
+    function _setupL2s() internal {
+        config = ScriptTools.readInput("integration");
+
+        rootDomain = new RootDomain(config, getRelativeChain("mainnet"));
+        rootDomain.selectFork();
+        
+        optimismDomain = new OptimismDomain(config, getRelativeChain("optimism"), rootDomain);
+    }
+
+    function testL2Spells() public {
+        _setupL2s();
     }
 }

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -431,7 +431,7 @@ contract DssSpellTest is DssSpellTestBase {
 
         arbitrumDomain.selectFork();
 
-        // Check that the L2 Optimism Spell is there and configured
+        // Check that the L2 Arbitrum Spell is there and configured
         L2Spell arbitrumSpell = L2Spell(0x11Dc6Ed4C08Da38B36709a6C8DBaAC0eAeDD48cA);
         L2Gateway arbitrumGateway = L2Gateway(arbitrumSpell.gateway());
         assertEq(address(arbitrumGateway), 0x8334a747731Be3a58bCcAf9a3D35EbC968806223, "l2-arbitrum-wrong-gateway");
@@ -451,10 +451,10 @@ contract DssSpellTest is DssSpellTestBase {
 
         // switch to Optimism domain and relay the spell from L1
         // the `true` keeps us on Optimism rather than `rootDomain.selectFork()
-        // optimismDomain.relayFromHost(true);
+        optimismDomain.relayFromHost(true);
 
         // Validate post-spell state
-        // assertEq(optimismGateway.validDomains(optDstDomain), 0, "l2-optimism-invalid-dst-domain");
+        assertEq(optimismGateway.validDomains(optDstDomain), 0, "l2-optimism-invalid-dst-domain");
 
         // switch to Arbitrum domain and relay the spell from L1
         // the `true` keeps us on Arbitrum rather than `rootDomain.selectFork()

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -403,14 +403,13 @@ contract DssSpellTest is DssSpellTestBase {
     }
 
     function _setupL2s() internal {
+        vm.makePersistent(address(spell), address(spell.action()));
+
         config = ScriptTools.readInput("integration");
 
         rootDomain = new RootDomain(config, getRelativeChain("mainnet"));
         optimismDomain = new OptimismDomain(config, getRelativeChain("optimism"), rootDomain);
         arbitrumDomain = new ArbitrumDomain(config, getRelativeChain("arbitrum_one"), rootDomain);
-
-        vm.makePersistent(address(spell));
-        vm.makePersistent(address(spell.action()));
     }
 
     function testL2OptimismSpell() public {

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -20,6 +20,7 @@ import "./DssSpell.t.base.sol";
 
 import {RootDomain} from "dss-test/domains/RootDomain.sol";
 import {OptimismDomain} from "dss-test/domains/OptimismDomain.sol";
+import {ArbitrumDomain} from "dss-test/domains/ArbitrumDomain.sol";
 
 interface L2Spell {
     function dstDomain() external returns (bytes32);
@@ -34,6 +35,7 @@ contract DssSpellTest is DssSpellTestBase {
     string         config;
     RootDomain     rootDomain;
     OptimismDomain optimismDomain;
+    ArbitrumDomain arbitrumDomain;
 
     // DO NOT TOUCH THE FOLLOWING TESTS, THEY SHOULD BE RUN ON EVERY SPELL
     function testGeneral() public {
@@ -405,6 +407,7 @@ contract DssSpellTest is DssSpellTestBase {
 
         rootDomain = new RootDomain(config, getRelativeChain("mainnet"));
         optimismDomain = new OptimismDomain(config, getRelativeChain("optimism"), rootDomain);
+        arbitrumDomain = new ArbitrumDomain(config, getRelativeChain("arbitrum_one"), rootDomain);
 
         vm.makePersistent(address(spell));
         vm.makePersistent(address(spell.action()));
@@ -415,25 +418,49 @@ contract DssSpellTest is DssSpellTestBase {
 
         optimismDomain.selectFork();
 
+        // Check that the L2 Optimism Spell is there and configured
         L2Spell optimismSpell = L2Spell(0xC077Eb64285b40C86B40769e99Eb1E61d682a6B4);
         L2Gateway optimismGateway = L2Gateway(optimismSpell.gateway());
         assertEq(address(optimismGateway), 0xd9e000C419F3aA4EA1C519497f5aF249b496a00f, "l2-optimism-wrong-gateway");
 
         bytes32 optDstDomain = optimismSpell.dstDomain();
         assertEq(optDstDomain, bytes32("ETH-GOER-A"), "l2-optimism-wrong-dst-domain");
+
+        // Validate pre-spell optimism state
         assertEq(optimismGateway.validDomains(optDstDomain), 1, "l2-optimism-invalid-dst-domain");
 
+        arbitrumDomain.selectFork();
+
+        // Check that the L2 Optimism Spell is there and configured
+        L2Spell arbitrumSpell = L2Spell(0x11Dc6Ed4C08Da38B36709a6C8DBaAC0eAeDD48cA);
+        L2Gateway arbitrumGateway = L2Gateway(arbitrumSpell.gateway());
+        assertEq(address(arbitrumGateway), 0x8334a747731Be3a58bCcAf9a3D35EbC968806223, "l2-arbitrum-wrong-gateway");
+
+        bytes32 arbDstDomain = arbitrumSpell.dstDomain();
+        assertEq(arbDstDomain, bytes32("ETH-GOER-A"), "l2-arbitrum-wrong-dst-domain");
+
+        // Validate pre-spell arbitrum state
+        assertEq(arbitrumGateway.validDomains(arbDstDomain), 1, "l2-arbitrum-invalid-dst-domain");
+
+        // Cast the L1 Spell
         rootDomain.selectFork();
 
         _vote(address(spell));
         _scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
 
-        // switch to optimism domain and relay the spell from L1
+        // switch to Optimism domain and relay the spell from L1
         // the `true` keeps us on Optimism rather than `rootDomain.selectFork()
-        optimismDomain.relayFromHost(true);
+        // optimismDomain.relayFromHost(true);
 
-        assertEq(optimismGateway.validDomains(optDstDomain), 0, "l2-optimism-invalid-dst-domain");
-        // OptGateway opt_gateway = 0xd9e000C419F3aA4EA1C519497f5aF249b496a00f;
+        // Validate post-spell state
+        // assertEq(optimismGateway.validDomains(optDstDomain), 0, "l2-optimism-invalid-dst-domain");
+
+        // switch to Arbitrum domain and relay the spell from L1
+        // the `true` keeps us on Arbitrum rather than `rootDomain.selectFork()
+        arbitrumDomain.relayFromHost(true);
+
+        // Validate post-spell state
+        assertEq(arbitrumGateway.validDomains(arbDstDomain), 0, "l2-arbitrum-invalid-dst-domain");
     }
 }

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -413,7 +413,7 @@ contract DssSpellTest is DssSpellTestBase {
         vm.makePersistent(address(spell.action()));
     }
 
-    function testL2Spells() public {
+    function testL2OptimismSpell() public {
         _setupL2s();
 
         optimismDomain.selectFork();
@@ -428,6 +428,23 @@ contract DssSpellTest is DssSpellTestBase {
 
         // Validate pre-spell optimism state
         assertEq(optimismGateway.validDomains(optDstDomain), 1, "l2-optimism-invalid-dst-domain");
+        // Cast the L1 Spell
+        rootDomain.selectFork();
+
+        _vote(address(spell));
+        _scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        // switch to Optimism domain and relay the spell from L1
+        // the `true` keeps us on Optimism rather than `rootDomain.selectFork()
+        optimismDomain.relayFromHost(true);
+
+        // Validate post-spell state
+        assertEq(optimismGateway.validDomains(optDstDomain), 0, "l2-optimism-invalid-dst-domain");
+    }
+
+    function testL2ArbitrumSpell() public {
+        _setupL2s();
 
         arbitrumDomain.selectFork();
 
@@ -448,13 +465,6 @@ contract DssSpellTest is DssSpellTestBase {
         _vote(address(spell));
         _scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
-
-        // switch to Optimism domain and relay the spell from L1
-        // the `true` keeps us on Optimism rather than `rootDomain.selectFork()
-        optimismDomain.relayFromHost(true);
-
-        // Validate post-spell state
-        assertEq(optimismGateway.validDomains(optDstDomain), 0, "l2-optimism-invalid-dst-domain");
 
         // switch to Arbitrum domain and relay the spell from L1
         // the `true` keeps us on Arbitrum rather than `rootDomain.selectFork()

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -419,6 +419,7 @@ contract DssSpellTest is DssSpellTestBase {
 
         // Check that the L2 Optimism Spell is there and configured
         L2Spell optimismSpell = L2Spell(0xC077Eb64285b40C86B40769e99Eb1E61d682a6B4);
+
         L2Gateway optimismGateway = L2Gateway(optimismSpell.gateway());
         assertEq(address(optimismGateway), 0xd9e000C419F3aA4EA1C519497f5aF249b496a00f, "l2-optimism-wrong-gateway");
 
@@ -449,6 +450,7 @@ contract DssSpellTest is DssSpellTestBase {
 
         // Check that the L2 Arbitrum Spell is there and configured
         L2Spell arbitrumSpell = L2Spell(0x11Dc6Ed4C08Da38B36709a6C8DBaAC0eAeDD48cA);
+
         L2Gateway arbitrumGateway = L2Gateway(arbitrumSpell.gateway());
         assertEq(address(arbitrumGateway), 0x8334a747731Be3a58bCcAf9a3D35EbC968806223, "l2-arbitrum-wrong-gateway");
 

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -94,8 +94,8 @@ contract Config {
         // Values for spell-specific parameters
         //
         spellValues = SpellValues({
-            deployed_spell:                 address(0xF39BBaaAf13b84e535Ca85E6724054a510457812),     // populate with deployed spell if deployed
-            deployed_spell_created:         1674571680,              // use `./scripts/get-created-timestamp.sh <deployment-tx>`
+            deployed_spell:                 address(0),     // populate with deployed spell if deployed
+            deployed_spell_created:         0,              // use `./scripts/get-created-timestamp.sh <deployment-tx>`
             previous_spell:                 address(0),     // supply if there is a need to test prior to its cast() function being called on-chain.
             office_hours_enabled:           false,          // true if officehours is expected to be enabled in the spell
             expiration_threshold:           30 days         // Amount of time before spell expires


### PR DESCRIPTION
# Description

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in Goerli changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell to Goerli `ETH_GAS_LIMIT="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Ensure contract is verified on `Goerli` etherscan
- [ ] Change test to use Goerli spell address and deploy timestamp
- [ ] Cast spell on Goerli `make spell="0x-deployed-spell-address" cast-spell`
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `DssSpell.sol`, `DssSpell.t.sol` and `DssSpell.t.base.sol`
- [ ] `squash and merge` this PR
