### PR TITLE
Improve `get-deploy-info.sh`

### DIFF
--- a/scripts/get-deploy-info.sh
+++ b/scripts/get-deploy-info.sh
@@ -23,8 +23,8 @@ KEY_BLOCK="deployed_spell_block"
 timestamp=$(cast block "$(cast tx "${TXHASH}"|grep blockNumber|awk '{print $2}')"|grep timestamp|awk '{print $2}')
 block=$(cast tx "${TXHASH}"|grep blockNumber|awk '{print $2}')
 
-sed -i "s/\($KEY_TIMESTAMP *: *\)[0-9]\+/\1$timestamp/g" "$SOURCE"
-sed -i "s/\($KEY_BLOCK *: *\)[0-9]\+/\1$block/g" "$SOURCE"
+sed -i "s/\($KEY_TIMESTAMP *: *\)[0-9]\+/\1$timestamp/" "$SOURCE"
+sed -i "s/\($KEY_BLOCK *: *\)[0-9]\+/\1$block/" "$SOURCE"
 
 echo -e "Network: $(cast chain)"
 echo "config.sol updated with deployed timestamp and block"

--- a/scripts/get-deploy-info.sh
+++ b/scripts/get-deploy-info.sh
@@ -16,6 +16,15 @@ do
     esac
 done
 
+SOURCE="src/test/config.sol"
+KEY_TIMESTAMP="deployed_spell_created"
+KEY_BLOCK="deployed_spell_block"
+
+timestamp=$(cast block "$(cast tx "${TXHASH}"|grep blockNumber|awk '{print $2}')"|grep timestamp|awk '{print $2}')
+block=$(cast tx "${TXHASH}"|grep blockNumber|awk '{print $2}')
+
+sed -i "s/\($KEY_TIMESTAMP *: *\)[0-9]\+/\1$timestamp/g" "$SOURCE"
+sed -i "s/\($KEY_BLOCK *: *\)[0-9]\+/\1$block/g" "$SOURCE"
+
 echo -e "Network: $(cast chain)"
-echo "timestamp: $(cast block "$(cast tx "${TXHASH}"|grep blockNumber|awk '{print $2}')"|grep timestamp|awk '{print $2}')"
-echo "block: $(cast tx "${TXHASH}"|grep blockNumber|awk '{print $2}')"
+echo "config.sol updated with deployed timestamp and block"


### PR DESCRIPTION
## Rationale

Following #166 discussion on parsing `config.sol` to replace deployed block and timestamp, the current proposed change shows how the script could be improved to automatically find and replace those values via key-value parsing using `sed`.

In this particular case `get-deploy-info.sh` have been edited to include such improvement but ideally this could be integrated directly into the `deploy.sh` script.

Opened for discussion and as PoC for the `sed` component that could be reused elsewhere as part of the spell crafting and reviewing automation process.

Tested with archived spell:
`make deploy-info tx=0x6728514cf65854f3c7efe63066b843abe443eab8930122e1e93e01b4806117e0`

Output:
```
./scripts/get-deploy-info.sh tx=0x6728514cf65854f3c7efe63066b843abe443eab8930122e1e93e01b4806117e0
Network: goerli
config.sol updated with deployed timestamp and block
```


