### PR TITLE
Improve `deploy.sh`

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,4 +11,4 @@ make && spell_address=$(dapp create DssSpell)
 
 ./scripts/verify.py DssSpell "$spell_address"
 
-sed -Ei "s/($KEY: *address\()(0x[0-9a-fA-F]{40}\))/\1$spell_address)/" "$SOURCE"
+sed -Ei "s/($KEY: *address\()(0x[a-fA-F0-9]{40}|0)\)/\1$spell_address)/" "$SOURCE"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,6 +4,11 @@ set -e
 [[ "$(cast chain --rpc-url="$ETH_RPC_URL")" == "goerli" ]] || { echo "Please set a Goerli ETH_RPC_URL"; exit 1; }
 [[ "$ETHERSCAN_API_KEY" ]] || { echo "Please set ETHERSCAN_API_KEY"; exit 1; }
 
-make && \
-  dapp create DssSpell | \
-  xargs ./scripts/verify.py DssSpell
+SOURCE="src/test/config.sol"
+KEY="deployed_spell"
+
+make && spell_address=$(dapp create DssSpell)
+
+./scripts/verify.py DssSpell "$spell_address"
+
+sed -Ei "s/($KEY: *address\()(0x[0-9a-fA-F]{40}\))/\1$spell_address)/" "$SOURCE"


### PR DESCRIPTION
## Rationale

Following #170 pattern I've extended the `deploy.sh` script behaviour to automatically edit `config.sol` by replacing the address with the deployed one (works with both pre-existing `address(0)` or with deployed spell address `address(0x123)`.

Opened for discussion as this could be merged together with #170 to automate further but for now it provides a way to automate further spell crafting process.

A nice add-on would be a commit like pattern as for `dapp-init`.
