### PR TITLE
Port PSM test fix from mainnet

### DIFF
--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -282,7 +282,7 @@ contract DssSpellTest is DssSpellTestBase {
     }
 
     // leave public for now as this is acting like a config tests
-    function testPSMs() private { // Disabled since some PSMs on mainnet are maxed out
+    function testPSMs() public {
         _vote(address(spell));
         _scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
@@ -313,8 +313,8 @@ contract DssSpellTest is DssSpellTestBase {
             ClipAbstract(addr.addr("MCD_CLIP_PSM_PAX_A")),
             addr.addr("PIP_PAX"),
             PsmAbstract(addr.addr("MCD_PSM_PAX_A")),
-            20,  // tin
-            0    // tout
+            0,   // tin
+            100    // tout
         );
 
         _ilk = "PSM-USDC-A";
@@ -328,10 +328,9 @@ contract DssSpellTest is DssSpellTestBase {
             ClipAbstract(addr.addr("MCD_CLIP_PSM_USDC_A")),
             addr.addr("PIP_USDC"),
             PsmAbstract(addr.addr("MCD_PSM_USDC_A")),
-            0,   // tin
+            100,   // tin
             0    // tout
         );
-
     }
 
     // @dev when testing new vest contracts, use the explicit id when testing to assist in
@@ -461,22 +460,5 @@ contract DssSpellTest is DssSpellTestBase {
 
         // Validate post-spell state
         assertEq(arbitrumGateway.validDomains(arbDstDomain), 0, "l2-arbitrum-invalid-dst-domain");
-    }
-
-    function testPSMTinTout() public {
-        PsmAbstract psmUsdc = PsmAbstract(addr.addr("MCD_PSM_USDC_A"));
-        PsmAbstract psmPax  = PsmAbstract(addr.addr("MCD_PSM_PAX_A"));
-
-        assertEq(psmUsdc.tin(), 0);
-        assertEq(psmPax.tin(), 0.002 * 10**18);
-        assertEq(psmPax.tout(), 0);
-
-        _vote(address(spell));
-        _scheduleWaitAndCast(address(spell));
-        assertTrue(spell.done());
-
-        assertEq(psmUsdc.tin(), 0.01 * 10**18);
-        assertEq(psmPax.tin(), 0);
-        assertEq(psmPax.tout(), 0.01 * 10**18);
     }
 }


### PR DESCRIPTION
# Description

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in Goerli changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell to Goerli `ETH_GAS_LIMIT="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Ensure contract is verified on `Goerli` etherscan
- [ ] Change test to use Goerli spell address and deploy timestamp
- [ ] Cast spell on Goerli `make spell="0x-deployed-spell-address" cast-spell`
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `DssSpell.sol`, `DssSpell.t.sol` and `DssSpell.t.base.sol`
- [ ] `squash and merge` this PR
