### PR TITLE
Fix: `make test-forge match="<test>"` is broken

### DIFF
--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -25,9 +25,9 @@ export FOUNDRY_ROOT_CHAINID=5
 if [[ -z "$MATCH" && -z "$BLOCK" ]]; then
     forge test --fork-url "$ETH_RPC_URL"
 elif [[ -z "$BLOCK" ]]; then
-    forge test --fork-url "$ETH_RPC_URL" --match "$MATCH" -vvv
+    forge test --fork-url "$ETH_RPC_URL" --match-test "$MATCH" -vvv
 elif [[ -z "$MATCH" ]]; then
     forge test --fork-url "$ETH_RPC_URL" --fork-block-number "$BLOCK"
 else
-    forge test --fork-url "$ETH_RPC_URL" --match "$MATCH" --fork-block-number "$BLOCK" -vvv
+    forge test --fork-url "$ETH_RPC_URL" --match-test "$MATCH" --fork-block-number "$BLOCK" -vvv
 fi


### PR DESCRIPTION
The [`--match` flag was finally removed](https://book.getfoundry.sh/reference/forge/forge-test#test-options) from `forge` in favor of `--match-test`/`--match-contract`/`--match-path`.

`make test-forge` script is now broken.