### PR TITLE
Feature: add `no-match` option to `make test-forge` / Refactor: use `make test` instead of `make test-forge` in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,6 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Run tests
-        run: make test-forge
+        run: make test
         env:
           ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all                  :; DAPP_LIBRARIES=' lib/dss-exec-lib/src/DssExecLib.sol:Dss
                          dapp --use solc:0.8.16 build
 clean                :; forge clean
                         # Usage example: make test match=SpellIsCast
-test                 :; ./scripts/test-dssspell-forge.sh match="$(match)" block="$(block)"
+test                 :; ./scripts/test-dssspell-forge.sh no-match="$(no-match)" match="$(match)" block="$(block)"
 test-forge           :; ./scripts/test-dssspell-forge.sh no-match="$(no-match)" match="$(match)" block="$(block)"
 estimate             :; ./scripts/estimate-deploy-gas.sh
 deploy               :; ./scripts/deploy.sh

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all                  :; DAPP_LIBRARIES=' lib/dss-exec-lib/src/DssExecLib.sol:Dss
 clean                :; forge clean
                         # Usage example: make test match=SpellIsCast
 test                 :; ./scripts/test-dssspell-forge.sh match="$(match)" block="$(block)"
-test-forge           :; ./scripts/test-dssspell-forge.sh match="$(match)" block="$(block)"
+test-forge           :; ./scripts/test-dssspell-forge.sh no-match="$(no-match)" match="$(match)" block="$(block)"
 estimate             :; ./scripts/estimate-deploy-gas.sh
 deploy               :; ./scripts/deploy.sh
 deploy-info          :; ./scripts/get-deploy-info.sh tx=$(tx)

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -9,6 +9,7 @@ do
     VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
 
     case "$KEY" in
+            no-match)   NO_MATCH="$VALUE" ;;
             match)      MATCH="$VALUE" ;;
             block)      BLOCK="$VALUE" ;;
             *)
@@ -22,12 +23,16 @@ export FOUNDRY_OPTIMIZER=false
 export FOUNDRY_OPTIMIZER_RUNS=200
 export FOUNDRY_ROOT_CHAINID=5
 
-if [[ -z "$MATCH" && -z "$BLOCK" ]]; then
-    forge test --fork-url "$ETH_RPC_URL"
-elif [[ -z "$BLOCK" ]]; then
-    forge test --fork-url "$ETH_RPC_URL" --match-test "$MATCH" -vvv
-elif [[ -z "$MATCH" ]]; then
-    forge test --fork-url "$ETH_RPC_URL" --fork-block-number "$BLOCK"
-else
-    forge test --fork-url "$ETH_RPC_URL" --match-test "$MATCH" --fork-block-number "$BLOCK" -vvv
+EXTRA_ARGS=''
+
+if [[ -n "$MATCH" ]]; then
+    EXTRA_ARGS="${EXTRA_ARGS} -vvv --match-test ${MATCH}"
+elif [[ -n "$NO_MATCH" ]]; then
+    EXTRA_ARGS="${EXTRA_ARGS} -vvv --no-match-test ${NO_MATCH}"
 fi
+
+if [[ -n "$BLOCK" ]]; then
+    EXTRA_ARGS="${EXTRA_ARGS} --fork-block-number ${BLOCK}"
+fi
+
+forge test --fork-url "$ETH_RPC_URL" $EXTRA_ARGS

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -9,8 +9,8 @@ do
     VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
 
     case "$KEY" in
-            no-match)   NO_MATCH="$VALUE" ;;
             match)      MATCH="$VALUE" ;;
+            no-match)   NO_MATCH="$VALUE" ;;
             block)      BLOCK="$VALUE" ;;
             *)
     esac

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -23,16 +23,16 @@ export FOUNDRY_OPTIMIZER=false
 export FOUNDRY_OPTIMIZER_RUNS=200
 export FOUNDRY_ROOT_CHAINID=5
 
-EXTRA_ARGS=''
+TEST_ARGS=''
 
 if [[ -n "$MATCH" ]]; then
-    EXTRA_ARGS="${EXTRA_ARGS} -vvv --match-test ${MATCH}"
+    TEST_ARGS="${TEST_ARGS} -vvv --match-test ${MATCH}"
 elif [[ -n "$NO_MATCH" ]]; then
-    EXTRA_ARGS="${EXTRA_ARGS} -vvv --no-match-test ${NO_MATCH}"
+    TEST_ARGS="${TEST_ARGS} -vvv --no-match-test ${NO_MATCH}"
 fi
 
 if [[ -n "$BLOCK" ]]; then
-    EXTRA_ARGS="${EXTRA_ARGS} --fork-block-number ${BLOCK}"
+    TEST_ARGS="${TEST_ARGS} --fork-block-number ${BLOCK}"
 fi
 
-forge test --fork-url "$ETH_RPC_URL" $EXTRA_ARGS
+forge test --fork-url "$ETH_RPC_URL" $TEST_ARGS


### PR DESCRIPTION
Sometimes a spell crafter wants to re-run a couple of tests only for faster execution when using an external JSON RPC provider. For that we have the `match='<regex>'` option.

However there is a case where the crafter might want to run the entire test suite, but skip only the ones that take longer to execute. This can be useful when debugging spells, shortening the feedback loop.

This PR adds the `no-match='<regex>'` options which uses the `--no-match-test` option from `forge` to skip a couple of tests.

For instance, one could skip `testAuth` and `testAuthInSources` while iterating over the spell code and only run those heavy tests at the end:

```bash
make test-forge no-match='testAuth|testAuthInSources'
```
