### PR TITLE
Fix broken tests after casting a spell

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -282,6 +282,7 @@ contract DssSpellTestBase is Config, DssTest {
 
     function setUp() public {
         setValues(address(chief));
+        _castPreviousSpell();
 
         spellValues.deployed_spell_created = spellValues.deployed_spell != address(0)
             ? spellValues.deployed_spell_created
@@ -289,8 +290,6 @@ contract DssSpellTestBase is Config, DssTest {
         spell = spellValues.deployed_spell != address(0)
             ?  DssSpell(spellValues.deployed_spell)
             : new DssSpell();
-
-        _castPreviousSpell();
 
         if (spellValues.deployed_spell_block != 0 && spell.eta() != 0) {
             // if we have a deployed spell in the config

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -283,21 +283,33 @@ contract DssSpellTestBase is Config, DssTest {
     function setUp() public {
         setValues(address(chief));
 
-        spellValues.deployed_spell_created = spellValues.deployed_spell != address(0) ? spellValues.deployed_spell_created : block.timestamp;
+        spellValues.deployed_spell_created = spellValues.deployed_spell != address(0)
+            ? spellValues.deployed_spell_created
+            : block.timestamp;
+        spell = spellValues.deployed_spell != address(0)
+            ?  DssSpell(spellValues.deployed_spell)
+            : new DssSpell();
+
         _castPreviousSpell();
-        spell = spellValues.deployed_spell != address(0) ?
-            DssSpell(spellValues.deployed_spell) : new DssSpell();
 
         if (spellValues.deployed_spell_block != 0 && spell.eta() != 0) {
             // if we have a deployed spell in the config
             // we want to roll our fork to the block where it was deployed
             // this means the test suite will continue to accurately pass/fail
             // even if mainnet has already scheduled/cast the spell
-            vm.makePersistent(address(this));
             vm.makePersistent(address(rates));
             vm.makePersistent(address(addr));
             vm.makePersistent(address(deployers));
             vm.rollFork(spellValues.deployed_spell_block);
+
+            // Reset `eta` to `0`, otherwise the tests will fail with "This spell has already been scheduled".
+            // This is a workaround for the issue described here:
+            // @see { https://github.com/foundry-rs/foundry/issues/5739 }
+            vm.store(
+                address(spell),
+                bytes32(0),
+                bytes32(0)
+            );
         }
     }
 


### PR DESCRIPTION
## Context

The `setUp` function was supposed to take care of the scenario when the spell has already been cast using `rollFork`.

However, there seems to be an outstanding [issue](https://github.com/foundry-rs/foundry/issues/5739) on Foundry that prevents the proper setup.

The workaround is to manually overwrite the `eta` storage variable that is being read before using the `vm.store` cheatcode to ensure the spell can be scheduled and cast again.

---

Another small improvement: remove `vm.makePersistent(address(this))` from this function, because it is a superfluous call.

From the [docs](https://book.getfoundry.sh/cheatcodes/make-persistent?highlight=makeper#makepersistent):

> By default, only the test contract account and the caller are persistent across forks
