### PR TITLE
2024-03-08 Goerli Spell

### DIFF
--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -39,9 +39,66 @@ contract DssSpellAction is DssAction {
     //    https://ipfs.io/ipfs/QmVp4mhhbwWGTfbh2BzwQB9eiBrQBKiqcPRZCaAxNUaar6
     //
     // uint256 internal constant X_PCT_RATE = ;
+    uint256 internal constant FIFTEEN_PCT_RATE               = 1000000004431822129783699001;
+    uint256 internal constant FIFTEEN_PT_TWO_FIVE_PCT_RATE   = 1000000004500681640286189459;
+    uint256 internal constant FIFTEEN_PT_SEVEN_FIVE_PCT_RATE = 1000000004637953682059597074;
+    uint256 internal constant SIXTEEN_PCT_RATE               = 1000000004706367499604668374;
+    uint256 internal constant SIXTEEN_PT_TWO_FIVE_PCT_RATE   = 1000000004774634032180348552;
+    uint256 internal constant SIXTEEN_PT_FIVE_PCT_RATE       = 1000000004842753912590664903;
+    uint256 internal constant SIXTEEN_PT_SEVEN_FIVE_PCT_RATE = 1000000004910727769570159235;
+    uint256 internal constant SEVENTEEN_PT_TWO_FIVE_PCT_RATE = 1000000005046239908035965222;
+
+    // ---------- Math ----------
+    uint256 internal constant MILLION = 10 ** 6;
+    uint256 internal constant BILLION = 10 ** 9;
 
     function actions() public override {
+        // ---------- DSR Change ----------
+        // Forum: https://forum.makerdao.com/t/accelerated-proposal-rate-system-gsm-delay-psm-usdc-a-ttl-changes/23824
 
+        // Increase the DSR by 10% from 5% to 15%
+        DssExecLib.setDSR(FIFTEEN_PCT_RATE, /* doDrip = */ true);
+
+        // ---------- Stability Fee Changes ----------
+        // Forum: https://forum.makerdao.com/t/accelerated-proposal-rate-system-gsm-delay-psm-usdc-a-ttl-changes/23824
+
+        // Increase the ETH-A Stability Fee by 8.84% from 6.41% to 15.25%
+        DssExecLib.setIlkStabilityFee("ETH-A", FIFTEEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // Increase the ETH-B Stability Fee by 8.84% from 6.91% to 15.75%
+        DssExecLib.setIlkStabilityFee("ETH-B", FIFTEEN_PT_SEVEN_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // Increase the ETH-C Stability Fee by 8.84% from 6.16% to 15%
+        DssExecLib.setIlkStabilityFee("ETH-C", FIFTEEN_PCT_RATE, /* doDrip = */ true);
+
+        // Increase the WSTETH-A Stability Fee by 9.6% from 6.65% to 16.25%
+        DssExecLib.setIlkStabilityFee("WSTETH-A", SIXTEEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // Increase the WSTETH-B Stability Fee by 9.6% from 6.4% to 16%
+        DssExecLib.setIlkStabilityFee("WSTETH-B", SIXTEEN_PCT_RATE, /* doDrip = */ true);
+
+        // Increase the WBTC-A Stability Fee by 10.07% from 6.68% to 16.75%
+        DssExecLib.setIlkStabilityFee("WBTC-A", SIXTEEN_PT_SEVEN_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // Increase the WBTC-B Stability Fee by 10.07% from 7.18% to 17.25%
+        DssExecLib.setIlkStabilityFee("WBTC-B", SEVENTEEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // Increase the WBTC-C Stability Fee by 10.07% from 6.43% to 16.5%
+        DssExecLib.setIlkStabilityFee("WBTC-C", SIXTEEN_PT_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // ---------- GSM Change ----------
+        // Forum: https://forum.makerdao.com/t/accelerated-proposal-rate-system-gsm-delay-psm-usdc-a-ttl-changes/23824
+        // Note: skipped on goerli since GSM delay here has to be 60 seconds
+
+        // ---------- USDC PSM ttl Change ----------
+        // Forum: https://forum.makerdao.com/t/accelerated-proposal-rate-system-gsm-delay-psm-usdc-a-ttl-changes/23824
+
+        // Decrease the ttl by 12 hours from 24 hours to 12 hours
+        DssExecLib.setIlkAutoLineParameters("PSM-USDC-A", 10 * BILLION, 400 * MILLION, 12 hours);
+
+        // ---------- Trigger Spark Proxy Spell ----------
+        // Forum: https://forum.makerdao.com/t/accelerated-proposal-rate-system-gsm-delay-psm-usdc-a-ttl-changes/23824
+        // Note: skipped on goerli as spark spell is only deployed to mainnet
     }
 }
 

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -40,70 +40,8 @@ contract DssSpellAction is DssAction {
     //
     // uint256 internal constant X_PCT_RATE = ;
 
-    //  ---------- Math ----------
-    uint256 internal constant MILLION   = 10 ** 6;
-
-    // ---------- SBE parameter changes ----------
-    address internal immutable MCD_FLAP = DssExecLib.flap();
-
     function actions() public override {
-        // ---------- Delegate Compensation for February 2024 ----------
-        // Forum: https://forum.makerdao.com/t/february-2024-aligned-delegate-compensation/23766
-        // Note: payments are skipped on goerli
 
-        // BLUE - 41.67 MKR - 0xb6C09680D822F162449cdFB8248a7D3FC26Ec9Bf
-        // BONAPUBLICA - 41.67 MKR - 0x167c1a762B08D7e78dbF8f24e5C3f1Ab415021D3
-        // Cloaky - 41.67 MKR - 0x869b6d5d8FA7f4FFdaCA4D23FFE0735c5eD1F818
-        // TRUE NAME - 41.67 MKR - 0x612F7924c367575a0Edf21333D96b15F1B345A5d
-        // 0xDefensor - 23.71 MKR - 0x9542b441d65B6BF4dDdd3d4D2a66D8dCB9EE07a9
-        // JAG - 13.89 MKR - 0x58D1ec57E4294E4fe650D1CB12b96AE34349556f
-        // UPMaker - 13.89 MKR - 0xbB819DF169670DC71A16F58F55956FE642cc6BcD
-        // vigilant - 13.89 MKR - 0x2474937cB55500601BCCE9f4cb0A0A72Dc226F61
-        // PBG - 13.44 MKR - 0x8D4df847dB7FfE0B46AF084fE031F7691C6478c2
-        // Pipkin - 5.82 MKR - 0x0E661eFE390aE39f90a58b04CF891044e56DEDB7
-        // QGov - 4.48 MKR - 0xB0524D8707F76c681901b782372EbeD2d4bA28a6
-        // WBC - 4.03 MKR - 0xeBcE83e491947aDB1396Ee7E55d3c81414fB0D47
-
-
-        // ---------- Smart Burn Engine `hop` Update ----------
-        // Forum: https://forum.makerdao.com/t/smart-burn-engine-the-rate-of-mkr-accumulation-reconfiguration-and-transaction-analysis-parameter-reconfiguration-update-5/23737
-        // Poll: https://vote.makerdao.com/polling/Qmat6oFs
-
-        // Decrease the hop by 6,570 seconds from 26,280 seconds to 19,710 seconds.
-        DssExecLib.setValue(MCD_FLAP, "hop", 19_710);
-
-
-        // ---------- Launch Project Funding ----------
-        // Forum: https://forum.makerdao.com/t/utilization-of-the-launch-project-under-the-accessibility-scope/21468/12
-        // MIP: https://mips.makerdao.com/mips/details/MIP108#9-launch-project
-        // Note: payments are skipped on goerli
-
-        // Transfer 3,000,000 DAI to the Launch Project at 0x3C5142F28567E6a0F172fd0BaaF1f2847f49D02F
-        // Transfer 500 MKR to the Launch Project at 0x3C5142F28567E6a0F172fd0BaaF1f2847f49D02F
-
-
-        // ---------- Whistleblower Bounty Payment ----------
-        // Forum: https://forum.makerdao.com/t/ad-derecognition-due-to-operational-security-breach-02-02-2024/23619/10
-        // Note: payments are skipped on goerli
-
-        // Transfer 20.84 MKR to whistleblower at 0xCDDd2A697d472d1e8a0B1B188646c756d097b058
-
-
-        // ---------- WBTC vault gap Changes ----------
-        // Forum: https://forum.makerdao.com/t/stability-scope-parameter-changes-10-wbtc-a-c-dc-iam-gap/23765
-
-        // Increase the WBTC-A gap by 2 million DAI from 2 million DAI to 4 million DAI
-        DssExecLib.setIlkAutoLineParameters("WBTC-A", /* line = */ 500 * MILLION, /* gap = */ 4 * MILLION, /* ttl = */ 24 hours);
-
-        // Increase the WBTC-C gap by 6 million DAI from 2 million DAI to 8 million DAI
-        DssExecLib.setIlkAutoLineParameters("WBTC-C", /* line = */ 500 * MILLION, /* gap = */ 8 * MILLION, /* ttl = */ 24 hours);
-
-
-        // ---------- Spark Proxy Spell ----------
-        // Forum: https://forum.makerdao.com/t/feb-22-2024-proposed-changes-to-sparklend-for-upcoming-spell/23739
-        // Poll: https://vote.makerdao.com/polling/QmUE5xr8
-        // Poll: https://vote.makerdao.com/polling/QmRU6mmi
-        // Note: skipped on goerli as spark spell is only deployed to mainnet
     }
 }
 

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -92,9 +92,9 @@ contract Config {
         // Values for spell-specific parameters
         //
         spellValues = SpellValues({
-            deployed_spell:         address(0xc9F93a2b473B17cF6f1A7169AbAad5f61E3f8879), // populate with deployed spell if deployed
-            deployed_spell_created: 1709589792, // use `make deploy-info tx=<deployment-tx>` to obtain the timestamp
-            deployed_spell_block:   10635510,   // use `make deploy-info tx=<deployment-tx>` to obtain the block number
+            deployed_spell:         address(0), // populate with deployed spell if deployed
+            deployed_spell_created: 0, // use `make deploy-info tx=<deployment-tx>` to obtain the timestamp
+            deployed_spell_block:   0,   // use `make deploy-info tx=<deployment-tx>` to obtain the block number
             previous_spells:        prevSpells, // older spells to ensure are executed first
             office_hours_enabled:   false,      // true if officehours is expected to be enabled in the spell
             expiration_threshold:   30 days     // Amount of time before spell expires

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -104,7 +104,7 @@ contract Config {
         // Values for all system configuration changes
         //
         afterSpell.line_offset           = 500 * MILLION;  // Offset between the global line against the sum of local lines
-        afterSpell.pot_dsr               = 5_00;           // In basis points
+        afterSpell.pot_dsr               = 15_00;          // In basis points
         afterSpell.pause_delay           = 60 seconds;     // In seconds
         afterSpell.vow_wait              = 156 hours;      // In seconds
         afterSpell.vow_dump              = 250;            // In whole Dai units
@@ -137,7 +137,7 @@ contract Config {
             aL_ttl:       6 hours,         // In seconds
             line:         0,               // In whole Dai units  // Not checked here as there is auto line
             dust:         7_500,           // In whole Dai units
-            pct:          6_41,            // In basis points
+            pct:          15_25,            // In basis points
             mat:          14500,           // In basis points
             liqType:      "clip",          // "" or "flip" or "clip"
             liqOn:        true,            // If liquidations are enabled
@@ -162,7 +162,7 @@ contract Config {
             aL_ttl:       6 hours,
             line:         0,
             dust:         25 * THOUSAND,
-            pct:          6_91,
+            pct:          15_75,
             mat:          13000,
             liqType:      "clip",
             liqOn:        true,
@@ -187,7 +187,7 @@ contract Config {
             aL_ttl:       8 hours,
             line:         0,
             dust:         3_500,
-            pct:          6_16,
+            pct:          15_00,
             mat:          17000,
             liqType:      "clip",
             liqOn:        true,
@@ -287,7 +287,7 @@ contract Config {
             aL_ttl:       24 hours,
             line:         0,
             dust:         7_500,
-            pct:          6_68,
+            pct:          16_75,
             mat:          14500,
             liqType:      "clip",
             liqOn:        true,
@@ -312,7 +312,7 @@ contract Config {
             aL_ttl:       24 hours,
             line:         0,
             dust:         25 * THOUSAND,
-            pct:          7_18,
+            pct:          17_25,
             mat:          13000,
             liqType:      "clip",
             liqOn:        true,
@@ -337,7 +337,7 @@ contract Config {
             aL_ttl:       24 hours,
             line:         0,
             dust:         3_500,
-            pct:          6_43,
+            pct:          16_50,
             mat:          17500,
             liqType:      "clip",
             liqOn:        true,
@@ -759,7 +759,7 @@ contract Config {
             aL_enabled:   true,
             aL_line:      10 * BILLION,
             aL_gap:       400 * MILLION,
-            aL_ttl:       24 hours,
+            aL_ttl:       12 hours,
             line:         0,
             dust:         0,
             pct:          0,
@@ -1462,7 +1462,7 @@ contract Config {
             aL_ttl:       12 hours,
             line:         0,
             dust:         7_500,
-            pct:          6_65,
+            pct:          16_25,
             mat:          150_00,
             liqType:      "clip",
             liqOn:        true,
@@ -1487,7 +1487,7 @@ contract Config {
             aL_ttl:       12 hours,
             line:         0,
             dust:         3_500,
-            pct:          6_40,
+            pct:          16_00,
             mat:          175_00,
             liqType:      "clip",
             liqOn:        true,

--- a/src/test/starknet.t.sol
+++ b/src/test/starknet.t.sol
@@ -37,7 +37,7 @@ contract ConfigStarknet {
 
         starknetValues = StarknetValues({
             l2_spell:                  0,  // Set to zero if no spell is set.
-            core_implementation:       0x3CeCEe6B359fAc09c79Ca4032826894F7e660B33, // As at 2023-05-17
+            core_implementation:       0x55bBBE4C8E426Be2Ec6F5b05A1728f9AFCa1Eb5C, // As at 2024-03-13
             dai_bridge_isOpen:         1,                     // 1 open, 0 closed
             dai_bridge_ceiling:        5_000_000 * WAD,       // wei
             dai_bridge_maxDeposit:     type(uint256).max,     // wei


### PR DESCRIPTION
# Description
This PR backports 2024-03-08 out-of-schedule mainnet spell implemented here: https://github.com/makerdao/spells-mainnet/pull/399

# Contribution Checklist

- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [x] Every contract variable/method declared as public/external private/internal
- [x] Consider if this PR needs the `officeHours` modifier override
- [x] Verify expiration (`30 days` unless otherwise specified)
- [ ] ~~Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)~~
- [ ] ~~Validate all addresses used are in Goerli changelog or known~~
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell to Goerli `ETH_GAS_LIMIT="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Ensure contract is verified on `Goerli` etherscan
- [ ] Change test to use Goerli spell address and deploy timestamp
- [ ] Cast spell on Goerli `make spell="0x-deployed-spell-address" cast-spell`
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `DssSpell.sol`, `DssSpell.t.sol` and `DssSpell.t.base.sol`
- [ ] `squash and merge` this PR
